### PR TITLE
Support longer notes field on Nano X, fix BLE disconnect freeze, clear keys from memory

### DIFF
--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -2,16 +2,12 @@
 #include "cx.h"
 
 #include "algo_keys.h"
-
-// Allocate 64 bytes for privateKeyData because os_perso_derive_node_bip32
-// appears to write more than 32 bytes to this buffer.  However, we only
-// need 32 bytes for cx_ecfp_init_private_key..
-static uint8_t privateKeyData[64];
+#include <string.h>
 
 uint8_t publicKey[32];
 
-void
-algorand_key_derive(void)
+static void
+algorand_key_derive(uint8_t *privateKeyData)
 {
   uint32_t bip32Path[5];
 
@@ -26,7 +22,23 @@ algorand_key_derive(void)
 void
 algorand_private_key(cx_ecfp_private_key_t *privateKey)
 {
-  cx_ecfp_init_private_key(CX_CURVE_Ed25519, privateKeyData, 32, privateKey);
+  uint8_t privateKeyData[64];
+
+  // Zero out returned privateKey
+  explicit_bzero(privateKey, sizeof(*privateKey));
+
+  // Derive private key from internal master key, zero out intermediate private
+  // key data when done
+  BEGIN_TRY {
+    TRY {
+      algorand_key_derive(privateKeyData);
+      cx_ecfp_init_private_key(CX_CURVE_Ed25519, privateKeyData, 32, privateKey);
+    }
+    FINALLY {
+      explicit_bzero(privateKeyData, sizeof(privateKeyData));
+    }
+  }
+  END_TRY;
 }
 
 void
@@ -35,8 +47,24 @@ algorand_public_key(uint8_t *buf)
   cx_ecfp_private_key_t privateKey;
   cx_ecfp_public_key_t publicKey;
 
+  // Zero out return buf and publicKey to be computed (in case there is an
+  // exception before publicKey is filled in)
+  explicit_bzero(buf, 32);
+  explicit_bzero(&publicKey, sizeof(publicKey));
+
+  // Generate private key
   algorand_private_key(&privateKey);
-  cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
+
+  // Attempt to convert private key to public key, zero out privateKey
+  BEGIN_TRY {
+    TRY {
+      cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
+    }
+    FINALLY {
+      explicit_bzero(&privateKey, sizeof(privateKey));
+    }
+  }
+  END_TRY;
 
   // publicKey.W is 65 bytes: a header byte, followed by a 32-byte
   // x coordinate, followed by a 32-byte y coordinate.  The bytes

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -52,12 +52,11 @@ algorand_public_key(uint8_t *buf)
   explicit_bzero(buf, 32);
   explicit_bzero(&publicKey, sizeof(publicKey));
 
-  // Generate private key
-  algorand_private_key(&privateKey);
-
   // Attempt to convert private key to public key, zero out privateKey
   BEGIN_TRY {
     TRY {
+      // Generate private key
+      algorand_private_key(&privateKey);
       cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
     }
     FINALLY {

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -23,6 +23,9 @@ algorand_key_derive(uint8_t *privateKeyData)
 void
 algorand_private_key(cx_ecfp_private_key_t *privateKey)
 {
+  // Allocate 64 bytes for privateKeyData because os_perso_derive_node_bip32
+  // appears to write more than 32 bytes to this buffer.  However, we only
+  // need 32 bytes for cx_ecfp_init_private_key...
   uint8_t privateKeyData[64];
 
   // Zero out returned privateKey

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -52,10 +52,9 @@ algorand_public_key(uint8_t *buf)
   explicit_bzero(buf, 32);
   explicit_bzero(&publicKey, sizeof(publicKey));
 
-  // Attempt to convert private key to public key, zero out privateKey
+  // Attempt to convert private key to public key, zero out privateKey after
   BEGIN_TRY {
     TRY {
-      // Generate private key
       algorand_private_key(&privateKey);
       cx_ecfp_generate_pair(CX_CURVE_Ed25519, &publicKey, &privateKey, 1);
     }

--- a/src/algo_keys.c
+++ b/src/algo_keys.c
@@ -1,8 +1,9 @@
+#include <string.h>
+
 #include "os.h"
 #include "cx.h"
 
 #include "algo_keys.h"
-#include <string.h>
 
 uint8_t publicKey[32];
 

--- a/src/algo_keys.h
+++ b/src/algo_keys.h
@@ -2,6 +2,5 @@
 
 extern uint8_t publicKey[32];
 
-void algorand_key_derive(void);
 void algorand_private_key(cx_ecfp_private_key_t *privateKey);
 void algorand_public_key(uint8_t *buf);

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -106,8 +106,6 @@ encode_bin(uint8_t **p, uint8_t *e, uint8_t *bytes, int len)
   for (int i = 0; i < len; i++) {
     put_byte(p, e, bytes[i]);
   }
-
-  return;
 }
 
 static int

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -9,7 +9,11 @@ put_byte(uint8_t **p, uint8_t *e, uint8_t b)
 {
   if (*p < e) {
     *((*p)++) = b;
+    return;
   }
+
+  // Output buffer too short, caller should handle
+  THROW(0x6760);
 }
 
 static void

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -94,14 +94,20 @@ encode_bin(uint8_t **p, uint8_t *e, uint8_t *bytes, int len)
   if (len < (1 << 8)) {
     put_byte(p, e, BIN8);
     put_byte(p, e, len);
-    for (int i = 0; i < len; i++) {
-      put_byte(p, e, bytes[i]);
-    }
-    return;
+  } else if (len < (1 << 16)) {
+    put_byte(p, e, BIN16);
+    put_byte(p, e, len >> 8);
+    put_byte(p, e, len & 0xFF);
+  } else {
+    // Longer binary blobs not suppported
+    os_sched_exit(0);
   }
 
-  // Longer binary blobs not suppported
-  os_sched_exit(0);
+  for (int i = 0; i < len; i++) {
+    put_byte(p, e, bytes[i]);
+  }
+
+  return;
 }
 
 static int

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -54,6 +54,8 @@ struct txn_asset_config {
   struct asset_params params;
 };
 
+
+
 struct txn {
   enum TXTYPE type;
 
@@ -65,7 +67,12 @@ struct txn {
   char genesisID[32];
   uint8_t genesisHash[32];
 
+#if defined(TARGET_NANOX)
+  uint8_t note[1024];
+#else
   uint8_t note[32];
+#endif
+
   size_t note_len;
 
   // Fields for specific tx types

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -54,8 +54,6 @@ struct txn_asset_config {
   struct asset_params params;
 };
 
-
-
 struct txn {
   enum TXTYPE type;
 

--- a/src/algo_tx_dec.c
+++ b/src/algo_tx_dec.c
@@ -102,12 +102,18 @@ static void
 decode_bin_var(uint8_t **bufp, uint8_t *buf_end, uint8_t *res, size_t *reslen, size_t reslenmax)
 {
   uint8_t b = next_byte(bufp, buf_end);
-  if (b != BIN8) {
+  uint16_t bin_len = 0;
+
+  if (b == BIN8) {
+    bin_len = next_byte(bufp, buf_end);
+  } else if (b == BIN16) {
+    bin_len = next_byte(bufp, buf_end);
+    bin_len = (bin_len << 8) | next_byte(bufp, buf_end);
+  } else {
     snprintf(decode_err, sizeof(decode_err), "expected bin, found %d", b);
     THROW(INVALID_PARAMETER);
   }
 
-  uint8_t bin_len = next_byte(bufp, buf_end);
   if (bin_len > reslenmax) {
     snprintf(decode_err, sizeof(decode_err), "expected <= %d bin bytes, found %d", reslenmax, bin_len);
     THROW(INVALID_PARAMETER);

--- a/src/main.c
+++ b/src/main.c
@@ -114,12 +114,12 @@ algorand_main(void)
   // next timer callback in 500 ms
   UX_CALLBACK_SET_INTERVAL(500);
 
-  #if defined(TARGET_NANOX)
+#if defined(TARGET_NANOX)
   // enable bluetooth on nano x
   G_io_app.plane_mode = os_setting_get(OS_SETTING_PLANEMODE, NULL, 0);
   BLE_power(0, NULL);
   BLE_power(1, "Nano X");
-  #endif
+#endif
 
   // DESIGN NOTE: the bootloader ignores the way APDU are fetched. The only
   // goal is to retrieve APDU.
@@ -380,9 +380,9 @@ main(void)
   for (;;) {
     UX_INIT();
 
-  #if defined(TARGET_NANOS)
+#if defined(TARGET_NANOS)
     UX_MENU_INIT();
-  #endif
+#endif
 
     BEGIN_TRY {
       TRY {
@@ -407,5 +407,4 @@ main(void)
     }
     END_TRY;
   }
-
 }

--- a/src/main.c
+++ b/src/main.c
@@ -37,7 +37,11 @@ struct txn current_txn;
 /* A buffer for collecting msgpack-encoded transaction via APDUs,
  * as well as for msgpack-encoding transaction prior to signing.
  */
+#if defined(TARGET_NANOX)
+static uint8_t msgpack_buf[2048];
+#else
 static uint8_t msgpack_buf[1024];
+#endif
 static unsigned int msgpack_next_off;
 
 void

--- a/src/main.c
+++ b/src/main.c
@@ -388,6 +388,17 @@ io_exchange_al(unsigned char channel, unsigned short tx_len)
   return 0;
 }
 
+void app_exit(void) {
+  BEGIN_TRY_L(exit) {
+    TRY_L(exit) {
+      os_sched_exit(-1);
+    }
+    FINALLY_L(exit) {
+    }
+  }
+  END_TRY_L(exit);
+}
+
 __attribute__((section(".boot")))
 int
 main(void)
@@ -431,4 +442,6 @@ main(void)
     }
     END_TRY;
   }
+  app_exit();
+  return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -260,6 +260,9 @@ algorand_main(void)
           break;
         }
       }
+      CATCH(EXCEPTION_IO_RESET){
+        THROW(EXCEPTION_IO_RESET);
+      }
       CATCH_OTHER(e) {
         switch (e & 0xF000) {
         case 0x6000:
@@ -374,27 +377,35 @@ main(void)
   // ensure exception will work as planned
   os_boot();
 
-  UX_INIT();
+  for (;;) {
+    UX_INIT();
 
-#if defined(TARGET_NANOS)
-  UX_MENU_INIT();
-#endif
+  #if defined(TARGET_NANOS)
+    UX_MENU_INIT();
+  #endif
 
-  BEGIN_TRY {
-    TRY {
-      io_seproxyhal_init();
+    BEGIN_TRY {
+      TRY {
+        io_seproxyhal_init();
 
-      USB_power(0);
-      USB_power(1);
+        USB_power(0);
+        USB_power(1);
 
-      ui_idle();
+        ui_idle();
 
-      algorand_main();
+        algorand_main();
+      }
+      CATCH(EXCEPTION_IO_RESET) {
+        // Reset IO and UX
+        continue;
+      }
+      CATCH_ALL {
+        break;
+      }
+      FINALLY {
+      }
     }
-    CATCH_OTHER(e) {
-    }
-    FINALLY {
-    }
+    END_TRY;
   }
-  END_TRY;
+
 }

--- a/src/main.c
+++ b/src/main.c
@@ -111,8 +111,10 @@ algorand_main(void)
 
   msgpack_next_off = 0;
 
+#if defined(TARGET_NANOS)
   // next timer callback in 500 ms
   UX_CALLBACK_SET_INTERVAL(500);
+#endif
 
 #if defined(TARGET_NANOX)
   // enable bluetooth on nano x
@@ -316,10 +318,12 @@ io_event(unsigned char channel)
 
   case SEPROXYHAL_TAG_TICKER_EVENT:
     UX_TICKER_EVENT(G_io_seproxyhal_spi_buffer, {
+#if defined(TARGET_NANOS)
         // defaulty retrig very soon (will be overriden during
         // stepper_prepro)
         UX_CALLBACK_SET_INTERVAL(500);
         UX_REDISPLAY();
+#endif
     });
     break;
 

--- a/src/main.c
+++ b/src/main.c
@@ -62,12 +62,12 @@ txn_approve()
       algorand_private_key(&privateKey);
 
       int sig_len = cx_eddsa_sign(&privateKey,
-          0, CX_SHA512,
-          &msgpack_buf[0], msg_len,
-          NULL, 0,
-          G_io_apdu_buffer,
-          6+2*(32+1), // Formerly from cx_compliance_141.c
-          NULL);
+                                  0, CX_SHA512,
+                                  &msgpack_buf[0], msg_len,
+                                  NULL, 0,
+                                  G_io_apdu_buffer,
+                                  6+2*(32+1), // Formerly from cx_compliance_141.c
+                                  NULL);
 
       tx = sig_len;
       G_io_apdu_buffer[tx++] = 0x90;

--- a/src/msgpack.h
+++ b/src/msgpack.h
@@ -7,6 +7,7 @@
 #define BOOL_FALSE  0xc2
 #define BOOL_TRUE   0xc3
 #define BIN8        0xc4
+#define BIN16       0xc5
 #define UINT8       0xcc
 #define UINT16      0xcd
 #define UINT32      0xce


### PR DESCRIPTION
This PR:
- Handles BLE disconnects gracefully as in https://github.com/LedgerHQ/ledger-app-boilerplate/blob/master/src/main.c#L65
- Supports longer notes fields on the Nano X
- Tries to clear private keys when not in use
- Throws on an attempted OOB `put_byte` instead of silently failing