### PR TITLE
Fix BLE pairing screen bug on Nano X

### DIFF
--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -106,8 +106,6 @@ encode_bin(uint8_t **p, uint8_t *e, uint8_t *bytes, int len)
   for (int i = 0; i < len; i++) {
     put_byte(p, e, bytes[i]);
   }
-
-  return;
 }
 
 static int

--- a/src/algo_tx.c
+++ b/src/algo_tx.c
@@ -94,14 +94,20 @@ encode_bin(uint8_t **p, uint8_t *e, uint8_t *bytes, int len)
   if (len < (1 << 8)) {
     put_byte(p, e, BIN8);
     put_byte(p, e, len);
-    for (int i = 0; i < len; i++) {
-      put_byte(p, e, bytes[i]);
-    }
-    return;
+  } else if (len < (1 << 16)) {
+    put_byte(p, e, BIN16);
+    put_byte(p, e, len >> 8);
+    put_byte(p, e, len & 0xFF);
+  } else {
+    // Longer binary blobs not suppported
+    os_sched_exit(0);
   }
 
-  // Longer binary blobs not suppported
-  os_sched_exit(0);
+  for (int i = 0; i < len; i++) {
+    put_byte(p, e, bytes[i]);
+  }
+
+  return;
 }
 
 static int

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -54,6 +54,8 @@ struct txn_asset_config {
   struct asset_params params;
 };
 
+
+
 struct txn {
   enum TXTYPE type;
 
@@ -65,7 +67,12 @@ struct txn {
   char genesisID[32];
   uint8_t genesisHash[32];
 
+#if defined(TARGET_NANOX)
+  uint8_t note[1024];
+#else
   uint8_t note[32];
+#endif
+
   size_t note_len;
 
   // Fields for specific tx types

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -54,8 +54,6 @@ struct txn_asset_config {
   struct asset_params params;
 };
 
-
-
 struct txn {
   enum TXTYPE type;
 

--- a/src/algo_tx_dec.c
+++ b/src/algo_tx_dec.c
@@ -102,12 +102,18 @@ static void
 decode_bin_var(uint8_t **bufp, uint8_t *buf_end, uint8_t *res, size_t *reslen, size_t reslenmax)
 {
   uint8_t b = next_byte(bufp, buf_end);
-  if (b != BIN8) {
+  uint16_t bin_len = 0;
+
+  if (b == BIN8) {
+    bin_len = next_byte(bufp, buf_end);
+  } else if (b == BIN16) {
+    bin_len = next_byte(bufp, buf_end);
+    bin_len = (bin_len << 8) | next_byte(bufp, buf_end);
+  } else {
     snprintf(decode_err, sizeof(decode_err), "expected bin, found %d", b);
     THROW(INVALID_PARAMETER);
   }
 
-  uint8_t bin_len = next_byte(bufp, buf_end);
   if (bin_len > reslenmax) {
     snprintf(decode_err, sizeof(decode_err), "expected <= %d bin bytes, found %d", reslenmax, bin_len);
     THROW(INVALID_PARAMETER);

--- a/src/main.c
+++ b/src/main.c
@@ -114,12 +114,12 @@ algorand_main(void)
   // next timer callback in 500 ms
   UX_CALLBACK_SET_INTERVAL(500);
 
-  #if defined(TARGET_NANOX)
+#if defined(TARGET_NANOX)
   // enable bluetooth on nano x
   G_io_app.plane_mode = os_setting_get(OS_SETTING_PLANEMODE, NULL, 0);
   BLE_power(0, NULL);
   BLE_power(1, "Nano X");
-  #endif
+#endif
 
   // DESIGN NOTE: the bootloader ignores the way APDU are fetched. The only
   // goal is to retrieve APDU.
@@ -380,9 +380,9 @@ main(void)
   for (;;) {
     UX_INIT();
 
-  #if defined(TARGET_NANOS)
+#if defined(TARGET_NANOS)
     UX_MENU_INIT();
-  #endif
+#endif
 
     BEGIN_TRY {
       TRY {
@@ -407,5 +407,4 @@ main(void)
     }
     END_TRY;
   }
-
 }

--- a/src/main.c
+++ b/src/main.c
@@ -37,7 +37,11 @@ struct txn current_txn;
 /* A buffer for collecting msgpack-encoded transaction via APDUs,
  * as well as for msgpack-encoding transaction prior to signing.
  */
+#if defined(TARGET_NANOX)
+static uint8_t msgpack_buf[2048];
+#else
 static uint8_t msgpack_buf[1024];
+#endif
 static unsigned int msgpack_next_off;
 
 void

--- a/src/main.c
+++ b/src/main.c
@@ -260,6 +260,9 @@ algorand_main(void)
           break;
         }
       }
+      CATCH(EXCEPTION_IO_RESET){
+        THROW(EXCEPTION_IO_RESET);
+      }
       CATCH_OTHER(e) {
         switch (e & 0xF000) {
         case 0x6000:
@@ -374,27 +377,35 @@ main(void)
   // ensure exception will work as planned
   os_boot();
 
-  UX_INIT();
+  for (;;) {
+    UX_INIT();
 
-#if defined(TARGET_NANOS)
-  UX_MENU_INIT();
-#endif
+  #if defined(TARGET_NANOS)
+    UX_MENU_INIT();
+  #endif
 
-  BEGIN_TRY {
-    TRY {
-      io_seproxyhal_init();
+    BEGIN_TRY {
+      TRY {
+        io_seproxyhal_init();
 
-      USB_power(0);
-      USB_power(1);
+        USB_power(0);
+        USB_power(1);
 
-      ui_idle();
+        ui_idle();
 
-      algorand_main();
+        algorand_main();
+      }
+      CATCH(EXCEPTION_IO_RESET) {
+        // Reset IO and UX
+        continue;
+      }
+      CATCH_ALL {
+        break;
+      }
+      FINALLY {
+      }
     }
-    CATCH_OTHER(e) {
-    }
-    FINALLY {
-    }
+    END_TRY;
   }
-  END_TRY;
+
 }

--- a/src/main.c
+++ b/src/main.c
@@ -111,8 +111,10 @@ algorand_main(void)
 
   msgpack_next_off = 0;
 
+#if defined(TARGET_NANOS)
   // next timer callback in 500 ms
   UX_CALLBACK_SET_INTERVAL(500);
+#endif
 
 #if defined(TARGET_NANOX)
   // enable bluetooth on nano x
@@ -316,10 +318,12 @@ io_event(unsigned char channel)
 
   case SEPROXYHAL_TAG_TICKER_EVENT:
     UX_TICKER_EVENT(G_io_seproxyhal_spi_buffer, {
+#if defined(TARGET_NANOS)
         // defaulty retrig very soon (will be overriden during
         // stepper_prepro)
         UX_CALLBACK_SET_INTERVAL(500);
         UX_REDISPLAY();
+#endif
     });
     break;
 

--- a/src/msgpack.h
+++ b/src/msgpack.h
@@ -7,6 +7,7 @@
 #define BOOL_FALSE  0xc2
 #define BOOL_TRUE   0xc3
 #define BIN8        0xc4
+#define BIN16       0xc5
 #define UINT8       0xcc
 #define UINT16      0xcd
 #define UINT32      0xce


### PR DESCRIPTION
This PR adds one commit on top of https://github.com/LedgerHQ/ledger-app-algorand/pull/4, which has already been deployed.

The change removes calls to `UX_CALLBACK_SET_INTERVAL` on the Nano X. During bluetooth pairing, this was sometimes causing the "confirm pairing code" screen to get overwritten with the app's `ui_idle` flow.