### PR TITLE
Add proper exit function

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -368,6 +368,17 @@ io_exchange_al(unsigned char channel, unsigned short tx_len)
   return 0;
 }
 
+void app_exit(void) {
+  BEGIN_TRY_L(exit) {
+    TRY_L(exit) {
+      os_sched_exit(-1);
+    }
+    FINALLY_L(exit) {
+    }
+  }
+  END_TRY_L(exit);
+}
+
 __attribute__((section(".boot")))
 int
 main(void)
@@ -411,4 +422,6 @@ main(void)
     }
     END_TRY;
   }
+  app_exit();
+  return 0;
 }


### PR DESCRIPTION
This PR adds an `app_exit` function to match the boilerplate example.