### PR TITLE
Fix a USB race by initializing the globals before the USB

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -456,6 +456,8 @@ main(void)
         G_io_app.plane_mode = os_setting_get(OS_SETTING_PLANEMODE, NULL, 0);
 #endif
 
+        init_globals();
+
         USB_power(0);
         USB_power(1);
 
@@ -465,9 +467,6 @@ main(void)
 #endif
 
         ui_idle();
-
-        init_globals();
-
         algorand_main();
       }
       CATCH(EXCEPTION_IO_RESET) {


### PR DESCRIPTION
Fix a USB race by initializing the globals before managing the USB connexion.

This race crashed the nano S device when attempting at adding an Algorand account
within the Ledger Live when using (at least) a specific Windows version along with
a specific USB hub (Windos 10.0.18362 + an asus USB hub).