### PR TITLE
Application transaction enhancements - Blind Signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.swp
 /src/glyphs.*
 /tests/build
+cli/__pycache__/
+ledger/

--- a/src/algo_tx.h
+++ b/src/algo_tx.h
@@ -76,13 +76,13 @@ struct state_schema {
   uint64_t num_byteslice;
 };
 
-#define MAX_ACCT 2
+#define MAX_ACCT 4
 typedef uint8_t accounts_t[MAX_ACCT][32];
 
-#define MAX_ARG 2
+#define MAX_ARG 16
 #define MAX_ARGLEN 32
-#define MAX_FOREIGN_APPS 1
-#define MAX_FOREIGN_ASSETS 1
+#define MAX_FOREIGN_APPS 8
+#define MAX_FOREIGN_ASSETS 8
 #define MAX_APPROV_LEN 128
 #define MAX_CLEAR_LEN 32
 

--- a/src/algo_ui.h
+++ b/src/algo_ui.h
@@ -5,6 +5,9 @@
 
 extern char caption[20];
 extern char text[128];
+extern char blind_signing_flag;
+#define BLIND_SIGNING_DISABLED 0
+#define BLIND_SIGNING_ENABLED 1
 
 void ui_idle();
 void ui_address_approval();
@@ -13,6 +16,9 @@ void ux_approve_txn();
 
 void ui_text_put(const char *msg);
 void ui_text_put_u64(uint64_t v);
+
+void switch_settings_blind_signing();
+void ui_warning_blind_signing_data(void);
 
 #define ALGORAND_DECIMALS 6
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,8 @@ unsigned int msgpack_next_off;
 
 struct pubkey_s public_key;
 
+char blind_signing_flag;
+
 void user_approval_denied(void)
 {
   G_io_apdu_buffer[0] = 0x69;
@@ -46,6 +48,7 @@ static void init_globals(void) {
   explicit_bzero(&current_txn, sizeof(current_txn));
   explicit_bzero(&public_key, sizeof(public_key));
   msgpack_next_off = 0;
+  blind_signing_flag = BLIND_SIGNING_DISABLED;
 }
 
 static void handle_sign_payment(uint8_t ins)

--- a/src/ui_idle.c
+++ b/src/ui_idle.c
@@ -1,9 +1,12 @@
 #include "os.h"
 #include "os_io_seproxyhal.h"
+#include "str.h"
 #include "algo_ui.h"
 #include "ux.h"
 
-UX_FLOW_DEF_NOCB(
+void display_settings(const ux_flow_step_t* const start_step);
+
+UX_STEP_NOCB(
     ux_idle_flow_welcome_step,
     nn, //pnn,
     {
@@ -11,14 +14,22 @@ UX_FLOW_DEF_NOCB(
       "Application",
       "is ready",
     });
-UX_FLOW_DEF_NOCB(
+UX_STEP_NOCB(
     ux_idle_flow_version_step,
     bn,
     {
       "Version",
       APPVERSION,
     });
-UX_FLOW_DEF_VALID(
+UX_STEP_CB(
+    ux_idle_flow_settings_step,
+    pb,
+    display_settings(NULL),
+    {
+      &C_icon_dashboard_x,
+      "Settings",
+    });
+UX_STEP_CB(
     ux_idle_flow_exit_step,
     pb,
     os_sched_exit(-1),
@@ -29,10 +40,41 @@ UX_FLOW_DEF_VALID(
 UX_FLOW(ux_idle_flow,
   &ux_idle_flow_welcome_step,
   &ux_idle_flow_version_step,
+  &ux_idle_flow_settings_step,
   &ux_idle_flow_exit_step,
   FLOW_LOOP
 );
 
+UX_STEP_CB(
+    ux_settings_flow_1_step,
+    bnnn_paging,
+    switch_settings_blind_signing(),
+    {
+      .title = "Blind signing",
+      .text = text,
+    });
+UX_STEP_CB(
+    ux_settings_flow_2_step,
+    pb,
+    ui_idle(),
+    {
+      &C_icon_back_x,
+      "Back",
+    });
+UX_FLOW(ux_settings_flow,
+        &ux_settings_flow_1_step,
+        &ux_settings_flow_2_step);
+
+void display_settings(const ux_flow_step_t* const start_step) {
+    strlcpy(text, (blind_signing_flag ? "Enabled" : "NOT Enabled"), 12);
+    ux_flow_init(0, ux_settings_flow, start_step);
+}
+
+void switch_settings_blind_signing() {
+    char value = (blind_signing_flag ? BLIND_SIGNING_DISABLED : BLIND_SIGNING_ENABLED);
+    blind_signing_flag = value;
+    display_settings(&ux_settings_flow_1_step);
+}
 
 void
 ui_idle(void)

--- a/src/ui_txn.h
+++ b/src/ui_txn.h
@@ -15,7 +15,7 @@ typedef struct {
 #if defined(TARGET_NANOX) || defined(TARGET_NANOS2)
 #define TNX_BUFFER_SIZE 2048
 #else
-#define TNX_BUFFER_SIZE 900
+#define TNX_BUFFER_SIZE 700
 #endif
 extern uint8_t msgpack_buf[TNX_BUFFER_SIZE];
 extern unsigned int msgpack_next_off;

--- a/src/ui_txn2.c
+++ b/src/ui_txn2.c
@@ -133,7 +133,13 @@ UX_STEP_NOCB(
       "Review",
       "Transaction",
     });
-
+UX_STEP_NOCB(
+    ux_warning_blind_signing_data_step,
+    bn,
+    {
+      "Blind signing",
+      "requested",
+    });
 UX_STEP_INIT(
     ux_init_upper_border,
     NULL,
@@ -176,6 +182,14 @@ UX_FLOW_DEF_VALID(
       "Transaction"
     });
 
+UX_STEP_NOCB(
+    ux_txn_blind_signing_error_step,
+    bnnn_paging,
+    {
+      "Blind Signing",
+      "Required but disabled in Settings"
+    });
+
 UX_FLOW(ux_txn_flow,
   &ux_confirm_tx_init_flow_step,
 
@@ -187,7 +201,33 @@ UX_FLOW(ux_txn_flow,
   &ux_reject_tx_flow_step
 );
 
+UX_FLOW(ux_txn_blind_signing_flow,
+  &ux_confirm_tx_init_flow_step,
+  &ux_warning_blind_signing_data_step,
+
+  &ux_init_upper_border,
+  &ux_variable_display,
+  &ux_init_lower_border,
+
+  &ux_confirm_tx_finalize_step,
+  &ux_reject_tx_flow_step
+);
+
+UX_FLOW(ux_txn_blind_signing_error_flow,
+  &ux_txn_blind_signing_error_step,
+  &ux_reject_tx_flow_step
+);
+
+static inline bool should_blind_sign() {
+  return  (current_txn.type == APPLICATION) &&
+          ((current_txn.application.num_accounts > 2) ||
+          (current_txn.application.num_foreign_assets > 1) ||
+          (current_txn.application.num_foreign_apps > 1) ||
+          (current_txn.application.num_app_args > 2));
+}
+
 void ui_txn(void) {
+  bool blind_signing_required = false;
   PRINTF("Transaction:\n");
   PRINTF("  Type: %d\n", current_txn.type);
   PRINTF("  Sender: %.*h\n", 32, current_txn.sender);
@@ -220,5 +260,11 @@ void ui_txn(void) {
   if (G_ux.stack_count == 0) {
     ux_stack_push(); 
   }
-  ux_flow_init(0, ux_txn_flow, NULL);
+  blind_signing_required = should_blind_sign();
+  if ((blind_signing_flag == BLIND_SIGNING_DISABLED) && blind_signing_required)
+    ux_flow_init(0, ux_txn_blind_signing_error_flow, NULL);
+  else if ((blind_signing_flag == BLIND_SIGNING_ENABLED) && should_blind_sign())
+    ux_flow_init(0, ux_txn_blind_signing_flow, NULL);
+  else
+    ux_flow_init(0, ux_txn_flow, NULL);
 }

--- a/tests/test/test_sign_msgpack_payment.py
+++ b/tests/test/test_sign_msgpack_payment.py
@@ -181,7 +181,7 @@ def test_sign_msgpack_differnet_chunk_size(dongle, payment_txn, chunk_size):
 def test_sign_txn_larger_then_internal_buffer(dongle, payment_txn):
     """
     """
-    INTERNAL_BUFFER_SIZE = 900
+    INTERNAL_BUFFER_SIZE = 700
     decoded_txn = base64.b64decode(algosdk.encoding.msgpack_encode(payment_txn))
 
     payment_txn.note = ("1"*(INTERNAL_BUFFER_SIZE - len(decoded_txn) + len(payment_txn.note))).encode()  
@@ -201,7 +201,7 @@ def test_sign_txn_long_field(dongle, payment_txn):
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))
         
-    assert excinfo.value.sw == 0x6e00
+    assert excinfo.value.sw == 0x6700
 
 
 @pytest.mark.parametrize('account_id', [0, 1, 3, 7, 10, 42, 12345])

--- a/tests/test/test_sign_msgpack_teal.py
+++ b/tests/test/test_sign_msgpack_teal.py
@@ -177,13 +177,14 @@ def test_sign_msgpack_call_app_more_than_four_accounts(dongle, app_call_txn):
     decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))
-        
+
     assert excinfo.value.sw == 0x6e00
 
-def test_sign_msgpack_call_app_more_than_two_args(dongle, app_call_txn):
+def test_sign_msgpack_call_app_more_than_fifteen_args(dongle, app_call_txn):
     """
     """
-    app_call_txn.app_args.append(b'\0x02\0x00\0x00\0x00')
+    for x in range(14):
+        app_call_txn.app_args.append(b'\x01\x01\x01\x01')
     decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))

--- a/tests/test/test_sign_msgpack_teal.py
+++ b/tests/test/test_sign_msgpack_teal.py
@@ -155,14 +155,14 @@ def test_sign_msgpack_call_app_more_than_eight_foreign_apps(dongle, app_call_txn
     decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))
-        
+
     assert excinfo.value.sw == 0x6e00
 
-
-def test_sign_msgpack_call_app_more_than_one_foreign_asset(dongle, app_call_txn):
+def test_sign_msgpack_call_app_more_than_eight_foreign_assets(dongle, app_call_txn):
     """
     """
-    app_call_txn.foreign_assets.append(6547014)
+    for x in range(8):
+        app_call_txn.foreign_assets.append(6547014+x)
     decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))

--- a/tests/test/test_sign_msgpack_teal.py
+++ b/tests/test/test_sign_msgpack_teal.py
@@ -147,10 +147,11 @@ def test_sign_msgpack_call_app_long_clear_app(dongle, app_create_txn):
         
     assert excinfo.value.sw == 0x6e00
 
-def test_sign_msgpack_call_app_more_than_one_foreign_app(dongle, app_call_txn):
+def test_sign_msgpack_call_app_more_than_eight_foreign_apps(dongle, app_call_txn):
     """
     """
-    app_call_txn.foreign_apps.append(81)
+    for x in range(8):
+        app_call_txn.foreign_apps.append(81+x)
     decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))

--- a/tests/test/test_sign_msgpack_teal.py
+++ b/tests/test/test_sign_msgpack_teal.py
@@ -294,3 +294,73 @@ def test_sign_msgpack_group_id_validate_display(dongle, app_call_txn, app_create
 
     verify_key = nacl.signing.VerifyKey(pubKey)
     verify_key.verify(smessage=b'TX' + decoded_txn, signature=txnSig)
+
+txn_blind_signing_error_labels = {
+    'blind signing', 'cancel'
+}
+
+def get_expected_messages_for_blind_signing_error():
+    messages =  [['blind signing', 'required but disabled in settings'],
+                 ['cancel', 'transaction']]
+
+    return messages
+
+def test_cancel_sign_msgpack_call_with_more_than_one_app_validate_display(dongle, app_call_txn):
+    """
+    """
+    app_call_txn.foreign_apps.append(81)
+    decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
+    with dongle.screen_event_handler(ui_interaction.confirm_on_lablel, txn_blind_signing_error_labels, 'cancel'):
+        logging.info(decoded_txn)
+        with pytest.raises(speculos.CommException) as excinfo:
+            _ = txn_utils.sign_algo_txn(dongle, decoded_txn)
+        assert excinfo.value.sw == 0x6985
+        messages = dongle.get_messages()
+    logging.info(messages)
+    logging.info(get_expected_messages_for_blind_signing_error())
+    assert get_expected_messages_for_blind_signing_error() == messages
+
+def test_cancel_sign_msgpack_call_with_more_than_one_foreign_asset_validate_display(dongle, app_call_txn):
+    """
+    """
+    app_call_txn.foreign_assets.append(6547014)
+    decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
+    with dongle.screen_event_handler(ui_interaction.confirm_on_lablel, txn_blind_signing_error_labels, 'cancel'):
+        logging.info(decoded_txn)
+        with pytest.raises(speculos.CommException) as excinfo:
+            _ = txn_utils.sign_algo_txn(dongle, decoded_txn)
+        assert excinfo.value.sw == 0x6985
+        messages = dongle.get_messages()
+    logging.info(messages)
+    logging.info(get_expected_messages_for_blind_signing_error())
+    assert get_expected_messages_for_blind_signing_error() == messages
+
+def test_cancel_sign_msgpack_call_with_more_than_two_foreign_accounts_validate_display(dongle, app_call_txn):
+    """
+    """
+    app_call_txn.accounts.append('R4DCCBODM4L7C6CKVOV5NYDPEYS2G5L7KC7LUYPLUCKBCOIZMYJPFUDTKE')
+    decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
+    with dongle.screen_event_handler(ui_interaction.confirm_on_lablel, txn_blind_signing_error_labels, 'cancel'):
+        logging.info(decoded_txn)
+        with pytest.raises(speculos.CommException) as excinfo:
+            _ = txn_utils.sign_algo_txn(dongle, decoded_txn)
+        assert excinfo.value.sw == 0x6985
+        messages = dongle.get_messages()
+    logging.info(messages)
+    logging.info(get_expected_messages_for_blind_signing_error())
+    assert get_expected_messages_for_blind_signing_error() == messages
+
+def test_cancel_sign_msgpack_call_with_more_than_two_app_args_validate_display(dongle, app_call_txn):
+    """
+    """
+    app_call_txn.app_args.append(b'\x01\x01\x01\x01')
+    decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
+    with dongle.screen_event_handler(ui_interaction.confirm_on_lablel, txn_blind_signing_error_labels, 'cancel'):
+        logging.info(decoded_txn)
+        with pytest.raises(speculos.CommException) as excinfo:
+            _ = txn_utils.sign_algo_txn(dongle, decoded_txn)
+        assert excinfo.value.sw == 0x6985
+        messages = dongle.get_messages()
+    logging.info(messages)
+    logging.info(get_expected_messages_for_blind_signing_error())
+    assert get_expected_messages_for_blind_signing_error() == messages

--- a/tests/test/test_sign_msgpack_teal.py
+++ b/tests/test/test_sign_msgpack_teal.py
@@ -166,13 +166,14 @@ def test_sign_msgpack_call_app_more_than_eight_foreign_assets(dongle, app_call_t
     decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))
-        
+
     assert excinfo.value.sw == 0x6e00
 
-def test_sign_msgpack_call_app_more_than_two_accounts(dongle, app_call_txn):
+def test_sign_msgpack_call_app_more_than_four_accounts(dongle, app_call_txn):
     """
     """
-    app_call_txn.accounts.append("R4DCCBODM4L7C6CKVOV5NYDPEYS2G5L7KC7LUYPLUCKBCOIZMYJPFUDTKE")
+    for x in range(3):
+        app_call_txn.accounts.append("R4DCCBODM4L7C6CKVOV5NYDPEYS2G5L7KC7LUYPLUCKBCOIZMYJPFUDTKE")
     decoded_txn= base64.b64decode(algosdk.encoding.msgpack_encode(app_call_txn))
     with pytest.raises(speculos.CommException) as excinfo:
         dongle.exchange(txn_utils.sign_algo_txn(dongle, decoded_txn))

--- a/tests/test_utils/sign_msgpack_teal2.py
+++ b/tests/test_utils/sign_msgpack_teal2.py
@@ -1,0 +1,69 @@
+
+from ctypes import sizeof
+from ledgerblue.comm import getDongle
+import struct
+import algosdk
+from algosdk.future import transaction
+import base64
+import os
+import sys
+import inspect
+currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parentdir = os.path.dirname(currentdir)
+sys.path.insert(0, parentdir)
+
+from test import  txn_utils
+
+
+def get_app_create_txn():
+    approve_app = b'\x02 \x05\x00\x05\x04\x02\x01&\x07\x04vote\tVoteBegin\x07VoteEnd\x05voted\x08RegBegin\x06RegEnd\x07Creator1\x18"\x12@\x00\x951\x19\x12@\x00\x871\x19$\x12@\x00y1\x19%\x12@\x00R1\x19!\x04\x12@\x00<6\x1a\x00(\x12@\x00\x01\x002\x06)d\x0f2\x06*d\x0e\x10@\x00\x01\x00"2\x08+c5\x005\x014\x00A\x00\x02"C6\x1a\x016\x1a\x01d!\x04\x08g"+6\x1a\x01f!\x04C2\x06\'\x04d\x0f2\x06\'\x05d\x0e\x10C"2\x08+c5\x005\x012\x06*d\x0e4\x00\x10A\x00\t4\x014\x01d!\x04\tg!\x04C1\x00\'\x06d\x12C1\x00\'\x06d\x12C\'\x061\x00g1\x1b$\x12@\x00\x01\x00\'\x046\x1a\x00\x17g\'\x056\x1a\x01\x17g)6\x1a\x02\x17g*6\x1a\x03\x17g!\x04C'
+    clear_pgm = b'\x02 \x01\x01'
+
+    # the approve_app is a compiled Tealscript taken from https://pyteal.readthedocs.io/en/stable/examples.html#periodic-payment
+    # we truncated the pgm because of the memory limit on the Ledeger 
+    approve_app = approve_app[:128]
+    local_ints = 2
+    local_bytes = 5
+    global_ints = 24 
+    global_bytes = 1
+    global_schema = transaction.StateSchema(global_ints, global_bytes)
+    local_schema = transaction.StateSchema(local_ints, local_bytes)
+    local_sp = transaction.SuggestedParams(fee= 2100, first=6002000, last=6003000,
+                                    gen="testnet-v1.0",
+                                    gh="SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",flat_fee=True)
+    txn = algosdk.future.transaction.ApplicationCreateTxn(sender="YK54TGVZ37C7P76GKLXTY2LAH2522VD3U2434HRKE7NMXA65VHJVLFVOE4",
+                                                         sp=local_sp,
+                                                         approval_program=approve_app,
+                                                         on_complete=transaction.OnComplete.NoOpOC.real,
+                                                         clear_program= clear_pgm,
+                                                         global_schema=global_schema,
+                                                         foreign_apps=[55, 56, 57, 58, 59, 60, 61, 62],
+                                                         foreign_assets=[
+                                                                31566700, 31566701, 31566702, 31566703,
+                                                                31566704, 31566705, 31566706, 31566707
+                                                             ],
+                                                         accounts=["7PKXMJB2577SQ6R6IGYRAZQ27TOOOTIGTOQGJB3L5SGZFBVVI4AHMKLCEI",
+                                                                  "NWBZBIROXZQEETCDKX6IZVVBV4EY637KCIX56LE5EHIQERCTSDYGXWG6PU",
+                                                                  "7PKXMJB2577SQ6R6IGYRAZQ27TOOOTIGTOQGJB3L5SGZFBVVI4AHMKLCEI",
+                                                                  "NWBZBIROXZQEETCDKX6IZVVBV4EY637KCIX56LE5EHIQERCTSDYGXWG6PU"],
+                                                         app_args=[
+                                                            b'\x11\x11\x11\x11',b'\x11\x11\x11\x11',
+                                                            b'\x11\x11\x11\x11',b'\x11\x11\x11\x11',
+                                                            b'\x11\x11\x11\x11',b'\x11\x11\x11\x11',
+                                                            b'\x11\x11\x11\x11',b'\x11\x11\x11\x11',
+                                                            b'\x11\x11\x11\x11',b'\x11\x11\x11\x11',
+                                                            b'\x11\x11\x11\x11',b'\x11\x11\x11\x11',
+                                                            b'\x11\x11\x11\x11',b'\x11\x11\x11\x11',
+                                                            b'\x11\x11\x11\x11'
+                                                         ],
+                                                         local_schema=local_schema )
+    return txn
+
+if __name__ == '__main__':
+    dongle = getDongle(True)
+    decoded_txn = base64.b64decode(algosdk.encoding.msgpack_encode(get_app_create_txn()))
+    print(decoded_txn)
+    print("decoded_txn len is ", len(decoded_txn))
+    txn_utils.sign_algo_txn(dongle, decoded_txn)
+    
+


### PR DESCRIPTION
Allow signing more complex application transactions. Algorand app should be better aligned against consensus v28 now.
PR introduces "Blind Signing" what means that in case of complex transaction not all transaction fields are displayed, however user is warned and has to explicitly enable "Blind Signing" support on Ledger.
  
