### PR TITLE
Replace ed25519 lib with pycryptodome for Python 3.12+ compat

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,6 @@
 pytest
 ragger[speculos,ledgerwallet]>=1.36.1
-ed25519==1.5
-pycryptodome
+pycryptodome==3.23.0
 canonicaljson>=2.0.0,<3.0.0
 cbor2>=5.7.1,<6.0.0
 msgpack>=1.1.2,<2.0.0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ import json
 import hashlib
 import base64
 import msgpack  # type: ignore[import-not-found]
-import ed25519  # type: ignore[import-not-found]
+from Crypto.Signature import eddsa  # type: ignore[import-not-found]
 import canonicaljson  # type: ignore[import-not-found]
 
 from .application_client.algorand_types import StdSigData
@@ -51,17 +51,11 @@ def check_signature_validity(
         True if signature is valid, False otherwise
     """
     try:
-        # Create verifying key from public key bytes
-        verifying_key = ed25519.VerifyingKey(public_key)
-
-        # Verify the signature directly without any prefix
-        verifying_key.verify(signature, message)
+        verifying_key = eddsa.import_public_key(public_key)
+        verifier = eddsa.new(verifying_key, mode="rfc8032")
+        verifier.verify(message, signature)
         return True
-    except ed25519.BadSignatureError:
-        # Signature verification failed
-        return False
-    except Exception:
-        # Other errors (e.g., invalid key format)
+    except (ValueError, TypeError):
         return False
 
 


### PR DESCRIPTION
[LedgerHQ/ledger-app-workflows#221](https://github.com/LedgerHQ/ledger-app-workflows/pull/221/changes) switched from ubuntu-22.04 to ubuntu-latest (which currently resolves to 24.04).

ubuntu-22.04 uses Python 3.10
ubuntu-24.04 uses Python 3.12

As a result the python-ed25519 package (pinned at 1.5, last released 2019) fails to build on Python 3.12 because its setup.py uses configparser.SafeConfigParser, which was removed in 3.12. [This breaks CI on the ubuntu-24.04 runner](https://github.com/LedgerHQ/app-algorand/actions/runs/25099197778/job/73543872181).

pycryptodome was already a test dependency and provides Ed25519 via Crypto.Signature.eddsa, so we remove a dependency rather than adding a different one.